### PR TITLE
Modified the calls to match changes upstream in pony-odbc

### DIFF
--- a/pony-odbc-pg/tests/test_integer_model.pony
+++ b/pony-odbc-pg/tests/test_integer_model.pony
@@ -48,7 +48,7 @@ class \nodoc\ iso _TestIntegerModel is PgQueryModel
     err
 
   fun ref fetch(h: ODBCHandleStmt tag): (SQLReturn val, _PCMResultI) =>
-    err = ODBCStmt.fetch(h)
+    err = ODBCStmtFFI.fetch(h)
     if (not is_success()) then return (err, result) end
 
     result.integer = pout.integer.native()

--- a/pony-odbc-pg/tests/test_multiple_params_model.pony
+++ b/pony-odbc-pg/tests/test_multiple_params_model.pony
@@ -57,7 +57,7 @@ class \nodoc\ iso _TestMultipleParamsModel is PgQueryModel
     err
 
   fun ref fetch(h: ODBCHandleStmt tag): (SQLReturn val, PgResultOut) =>
-    err = ODBCStmt.fetch(h)
+    err = ODBCStmtFFI.fetch(h)
     if (not is_success()) then return (err, result) end
 
     result.name = pout.name.native()

--- a/pony-odbc-pg/type_mapping.pony
+++ b/pony-odbc-pg/type_mapping.pony
@@ -4,9 +4,9 @@ use "pony-odbc/ctypes"
 use "pony-odbc/attributes"
 use "pony-odbc/instrumentation"
 
-type PgEnv is ODBCEnvC
-type PgDbc is ODBCDbcC
-type PgSth is ODBCSthC
+type PgEnv is ODBCEnv
+type PgDbc is ODBCDbc
+type PgSth is ODBCSth
 
 type PgInteger is SQLInteger
 type PgVarchar is SQLVarchar


### PR DESCRIPTION
On the pony-odbc side we renamed as follows:

ODBCEnv => ODBCEnvFFI
ODBCDbc => ODBCDbcFFI
ODBCSth => ODBCSthFFI

… and so on.